### PR TITLE
[Improvement] Overhaul improve the current command system & bug fixs

### DIFF
--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/BukkitCommands.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/BukkitCommands.java
@@ -10,6 +10,7 @@ import net.momirealms.sparrow.bukkit.command.CommandConfig;
 import net.momirealms.sparrow.bukkit.command.CommandFeature;
 import net.momirealms.sparrow.bukkit.command.feature.*;
 import net.momirealms.sparrow.bukkit.command.parser.CustomEnchantmentParser;
+import net.momirealms.sparrow.common.locale.SparrowCaptionFormatter;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.incendo.cloud.SenderMapper;
@@ -19,6 +20,7 @@ import org.incendo.cloud.bukkit.internal.CraftBukkitReflection;
 import org.incendo.cloud.bukkit.internal.RegistryReflection;
 import org.incendo.cloud.component.CommandComponent;
 import org.incendo.cloud.execution.ExecutionCoordinator;
+import org.incendo.cloud.minecraft.extras.MinecraftExceptionHandler;
 import org.incendo.cloud.paper.PaperCommandManager;
 import org.incendo.cloud.paper.parser.KeyedWorldParser;
 import org.incendo.cloud.setting.ManagerSetting;
@@ -113,6 +115,11 @@ public class BukkitCommands {
         } else if (this.manager.hasCapability(CloudBukkitCapabilities.ASYNCHRONOUS_COMPLETION)) {
             this.manager.registerAsynchronousCompletions();
         }
+
+        MinecraftExceptionHandler.<CommandSender>create(c -> plugin.getSenderFactory().getAudience(c))
+                .defaultHandlers()
+                .captionFormatter(new SparrowCaptionFormatter<>())
+                .registerTo(this.manager);
     }
 
     public void unregisterCommandFeatures() {

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/BukkitSenderFactory.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/BukkitSenderFactory.java
@@ -25,6 +25,7 @@
 
 package net.momirealms.sparrow.bukkit;
 
+import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import net.kyori.adventure.text.Component;
 import net.momirealms.sparrow.common.sender.Sender;
@@ -59,6 +60,11 @@ public class BukkitSenderFactory extends SenderFactory<SparrowBukkitPlugin, Comm
             return ((Player) sender).getUniqueId();
         }
         return Sender.CONSOLE_UUID;
+    }
+
+    @Override
+    protected Audience getAudience(CommandSender sender) {
+        return this.audiences.sender(sender);
     }
 
     @Override

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/ActionBarAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/ActionBarAdminCommand.java
@@ -24,7 +24,7 @@ public class ActionBarAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser())
+                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser(false))
                 .required("actionbar", StringParser.greedyFlagYieldingStringParser())
                 .flag(manager.flagBuilder("silent").withAliases("s"))
                 .flag(manager.flagBuilder("legacy-color").withAliases("l"))
@@ -34,18 +34,6 @@ public class ActionBarAdminCommand extends AbstractCommand {
                     String actionBarContent = commandContext.get("actionbar");
                     boolean legacy = commandContext.flags().hasFlag("legacy-color");
                     boolean silent = commandContext.flags().hasFlag("silent");
-                    if (players.size() == 0) {
-                        if (!silent)
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_PLAYER.build()
-                                            ),
-                                            true
-                                    );
-                        return;
-                    }
                     for (Player player : players) {
                         String json = AdventureHelper.componentToJson(AdventureHelper.getMiniMessage().deserialize(
                                 legacy ? AdventureHelper.legacyToMiniMessage(actionBarContent) : actionBarContent

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/AnvilAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/AnvilAdminCommand.java
@@ -22,24 +22,12 @@ public class AnvilAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser())
+                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser(false))
                 .flag(manager.flagBuilder("silent").withAliases("s"))
                 .handler(commandContext -> {
                     MultiplePlayerSelector selector = commandContext.get("player");
                     var players = selector.values();
                     boolean silent = commandContext.flags().hasFlag("silent");
-                    if (players.size() == 0) {
-                        if (!silent)
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_PLAYER.build()
-                                            ),
-                                            true
-                                    );
-                        return;
-                    }
                     for (Player player : players) {
                         player.openAnvil(null, true);
                     }

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/BroadcastAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/BroadcastAdminCommand.java
@@ -24,7 +24,7 @@ public class BroadcastAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser())
+                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser(false))
                 .required("message", StringParser.greedyFlagYieldingStringParser())
                 .flag(manager.flagBuilder("silent").withAliases("s"))
                 .flag(manager.flagBuilder("legacy-color").withAliases("l"))
@@ -34,18 +34,6 @@ public class BroadcastAdminCommand extends AbstractCommand {
                     var players = selector.values();
                     String message = commandContext.get("message");
                     boolean legacy = commandContext.flags().hasFlag("legacy-color");
-                    if (players.size() == 0) {
-                        if (!silent)
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_PLAYER.build()
-                                            ),
-                                            true
-                                    );
-                        return;
-                    }
                     for (Player player : players) {
                         SparrowBukkitPlugin.getInstance().getSenderFactory().wrap(player).sendMessage(AdventureHelper.getMiniMessage().deserialize(
                                 legacy ? AdventureHelper.legacyToMiniMessage(message) : message

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/CartographyTableAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/CartographyTableAdminCommand.java
@@ -22,24 +22,12 @@ public class CartographyTableAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser())
+                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser(false))
                 .flag(manager.flagBuilder("silent").withAliases("s"))
                 .handler(commandContext -> {
                     MultiplePlayerSelector selector = commandContext.get("player");
                     boolean silent = commandContext.flags().hasFlag("silent");
                     var players = selector.values();
-                    if (players.size() == 0) {
-                        if (!silent)
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_PLAYER.build()
-                                            ),
-                                            true
-                                    );
-                        return;
-                    }
                     for (Player player : players) {
                         player.openCartographyTable(null, true);
                     }

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/DyeAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/DyeAdminCommand.java
@@ -44,59 +44,47 @@ public class DyeAdminCommand extends AbstractCommand {
                     EquipmentSlot slot = optionalEquipmentSlot.orElse(EquipmentSlot.HAND);
                     MultipleEntitySelector selector = commandContext.get("entity");
                     var entities = selector.values();
-                    if (entities.size() == 0) {
-                        if (!silent) {
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_ENTITY.build()
-                                            ),
-                                            true
-                                    );
-                        }
-                        return;
-                    }
                     int i = 0;
                     Color color = Color.fromRGB(textColor.red(), textColor.green(), textColor.blue());
                     for (Entity entity : entities) {
                         if (entity instanceof LivingEntity livingEntity) {
                             EntityEquipment entityEquipment = livingEntity.getEquipment();
-                            if (entityEquipment != null) {
-                                ItemStack itemStack = entityEquipment.getItem(slot);
-                                if (!itemStack.isEmpty()) {
-                                    if (!(itemStack.getItemMeta() instanceof ColorableArmorMeta meta)) {
-                                        if (entities.size() != 1) continue;
-                                        SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                                .wrap(commandContext.sender())
-                                                .sendMessage(
-                                                        TranslationManager.render(
-                                                                Message.COMMANDS_ADMIN_DYE_FAILED_INCOMPATIBLE
-                                                                        .arguments(Component.translatable(itemStack.translationKey()))
-                                                                        .build()
-                                                        )
-                                                );
-                                        return;
-                                    }
-                                    meta.setColor(color);
-                                    itemStack.setItemMeta(meta);
-                                    entityEquipment.setItem(slot, itemStack);
-                                    ++i;
-                                    continue;
-                                }
-                                if (entities.size() != 1) continue;
-                                if (!silent)
+                            if (entityEquipment == null) {
+                                continue;
+                            }
+                            ItemStack itemStack = entityEquipment.getItem(slot);
+                            if (!itemStack.isEmpty()) {
+                                if (!(itemStack.getItemMeta() instanceof ColorableArmorMeta meta)) {
+                                    if (entities.size() != 1) continue;
                                     SparrowBukkitPlugin.getInstance().getSenderFactory()
                                             .wrap(commandContext.sender())
                                             .sendMessage(
                                                     TranslationManager.render(
-                                                            Message.COMMANDS_ADMIN_DYE_FAILED_ITEMLESS
-                                                                    .arguments(Component.text(livingEntity.getName()))
+                                                            Message.COMMANDS_ADMIN_DYE_FAILED_INCOMPATIBLE
+                                                                    .arguments(Component.translatable(itemStack.translationKey()))
                                                                     .build()
                                                     )
                                             );
-                                return;
+                                    return;
+                                }
+                                meta.setColor(color);
+                                itemStack.setItemMeta(meta);
+                                entityEquipment.setItem(slot, itemStack);
+                                ++i;
+                                continue;
                             }
+                            if (entities.size() != 1) continue;
+                            if (!silent)
+                                SparrowBukkitPlugin.getInstance().getSenderFactory()
+                                        .wrap(commandContext.sender())
+                                        .sendMessage(
+                                                TranslationManager.render(
+                                                        Message.COMMANDS_ADMIN_DYE_FAILED_ITEMLESS
+                                                                .arguments(Component.text(livingEntity.getName()))
+                                                                .build()
+                                                )
+                                        );
+                            return;
                         }
                         if (entities.size() != 1) continue;
                         if (!silent)

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/EnchantAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/EnchantAdminCommand.java
@@ -34,7 +34,7 @@ public class EnchantAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("entity", MultipleEntitySelectorParser.multipleEntitySelectorParser())
+                .required("entity", MultipleEntitySelectorParser.multipleEntitySelectorParser(false))
                 .required("enchantment", CustomEnchantmentParser.enchantmentParser())
                 .optional("level", IntegerParser.integerParser(1))
                 .optional("slot", EnumParser.enumParser(EquipmentSlot.class))
@@ -66,19 +66,6 @@ public class EnchantAdminCommand extends AbstractCommand {
                     boolean ignoreConflict = commandContext.flags().hasFlag("ignore-conflict");
                     MultipleEntitySelector selector = commandContext.get("entity");
                     Collection<Entity> targets = selector.values();
-                    if (targets.size() == 0) {
-                        if (!silent) {
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_ENTITY.build()
-                                            ),
-                                            true
-                                    );
-                        }
-                        return;
-                    }
                     for (Entity entity : targets) {
                         if (entity instanceof LivingEntity livingEntity) {
                             EntityEquipment entityEquipment = livingEntity.getEquipment();

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/EnderChestAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/EnderChestAdminCommand.java
@@ -24,24 +24,12 @@ public class EnderChestAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser())
+                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser(false))
                 .flag(manager.flagBuilder("silent").withAliases("s"))
                 .handler(commandContext -> {
                     MultiplePlayerSelector selector = commandContext.get("player");
                     boolean silent = commandContext.flags().hasFlag("silent");
                     var players = selector.values();
-                    if (players.size() == 0) {
-                        if (!silent)
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_PLAYER.build()
-                                            ),
-                                            true
-                                    );
-                        return;
-                    }
                     for (Player player : players) {
                         InventoryAccess.getInventoryUtils().openCustomInventory(player, player.getEnderChest(), new ShadedAdventureComponentWrapper(Component.translatable("container.enderchest")));
                     }

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/FeedAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/FeedAdminCommand.java
@@ -22,24 +22,12 @@ public class FeedAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser())
+                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser(false))
                 .flag(manager.flagBuilder("silent").withAliases("s"))
                 .handler(commandContext -> {
                     MultiplePlayerSelector selector = commandContext.get("player");
                     boolean silent = commandContext.flags().hasFlag("silent");
                     var players = selector.values();
-                    if (players.size() == 0) {
-                        if (!silent)
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_PLAYER.build()
-                                            ),
-                                            true
-                                    );
-                        return;
-                    }
                     for (Player player : players) {
                         player.setFoodLevel(20);
                         player.setSaturation(10f);

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/FlyAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/FlyAdminCommand.java
@@ -23,7 +23,7 @@ public class FlyAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser())
+                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser(false))
                 .required("fly", BooleanParser.booleanParser())
                 .flag(manager.flagBuilder("silent").withAliases("s"))
                 .handler(commandContext -> {
@@ -31,18 +31,6 @@ public class FlyAdminCommand extends AbstractCommand {
                     boolean fly = commandContext.get("fly");
                     var players = selector.values();
                     boolean silent = commandContext.flags().hasFlag("silent");
-                    if (players.size() == 0) {
-                        if (!silent)
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_PLAYER.build()
-                                            ),
-                                            true
-                                    );
-                        return;
-                    }
                     if (players.size() == 1) {
                         final Player player = players.iterator().next();
                         if (player.getAllowFlight() && fly) {

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/FlySpeedAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/FlySpeedAdminCommand.java
@@ -23,7 +23,7 @@ public class FlySpeedAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser())
+                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser(false))
                 .required("speed", FloatParser.floatParser(-1, 1))
                 .flag(manager.flagBuilder("silent").withAliases("s"))
                 .handler(commandContext -> {
@@ -31,18 +31,6 @@ public class FlySpeedAdminCommand extends AbstractCommand {
                     float speed = commandContext.get("speed");
                     boolean silent = commandContext.flags().hasFlag("silent");
                     var players = selector.values();
-                    if (players.size() == 0) {
-                        if (!silent)
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_PLAYER.build()
-                                            ),
-                                            true
-                                    );
-                        return;
-                    }
                     for (Player player : players) {
                         player.setFlySpeed(speed);
                     }

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/GrindStoneAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/GrindStoneAdminCommand.java
@@ -22,24 +22,12 @@ public class GrindStoneAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser())
+                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser(false))
                 .flag(manager.flagBuilder("silent").withAliases("s"))
                 .handler(commandContext -> {
                     MultiplePlayerSelector selector = commandContext.get("player");
                     boolean silent = commandContext.flags().hasFlag("silent");
                     var players = selector.values();
-                    if (players.size() == 0) {
-                        if (!silent)
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_PLAYER.build()
-                                            ),
-                                            true
-                                    );
-                        return;
-                    }
                     for (Player player : players) {
                         player.openGrindstone(null, true);
                     }

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/HealAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/HealAdminCommand.java
@@ -23,24 +23,12 @@ public class HealAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("entity", MultipleEntitySelectorParser.multipleEntitySelectorParser())
+                .required("entity", MultipleEntitySelectorParser.multipleEntitySelectorParser(false))
                 .flag(manager.flagBuilder("silent").withAliases("s"))
                 .handler(commandContext -> {
                     Selector<Entity> selector = commandContext.get("entity");
                     boolean silent = commandContext.flags().hasFlag("silent");
                     var entities = selector.values();
-                    if (entities.size() == 0) {
-                        if (!silent)
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_ENTITY.build()
-                                            ),
-                                            true
-                                    );
-                        return;
-                    }
                     for (Entity entity : entities) {
                         EntityUtils.heal(entity);
                     }

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/LoomAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/LoomAdminCommand.java
@@ -22,24 +22,12 @@ public class LoomAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser())
+                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser(false))
                 .flag(manager.flagBuilder("silent").withAliases("s"))
                 .handler(commandContext -> {
                     MultiplePlayerSelector selector = commandContext.get("player");
                     boolean silent = commandContext.flags().hasFlag("silent");
                     var players = selector.values();
-                    if (players.size() == 0) {
-                        if (!silent)
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_PLAYER.build()
-                                            ),
-                                            true
-                                    );
-                        return;
-                    }
                     for (Player player : players) {
                         player.openLoom(null, true);
                     }

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/PatrolAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/PatrolAdminCommand.java
@@ -75,7 +75,9 @@ public class PatrolAdminCommand extends AbstractCommand {
                             SparrowBukkitPlugin.getInstance().getSenderFactory()
                                     .wrap(commandContext.sender())
                                     .sendMessage(
-                                            Component.text("eeee?"),
+                                            TranslationManager.render(
+                                                    Message.COMMANDS_ADMIN_PATROL_FAILED_TARGET.build()
+                                            ),
                                             true
                                     );
                         }

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/ServerAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/ServerAdminCommand.java
@@ -10,7 +10,7 @@ import org.bukkit.entity.Player;
 import org.incendo.cloud.Command;
 import org.incendo.cloud.bukkit.BukkitCommandManager;
 import org.incendo.cloud.bukkit.data.MultiplePlayerSelector;
-import org.incendo.cloud.bukkit.parser.PlayerParser;
+import org.incendo.cloud.bukkit.parser.selector.MultiplePlayerSelectorParser;
 import org.incendo.cloud.parser.standard.StringParser;
 
 public class ServerAdminCommand extends AbstractCommand {
@@ -23,7 +23,7 @@ public class ServerAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("player", PlayerParser.playerParser())
+                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser(false))
                 .required("server", StringParser.stringParser())
                 .flag(manager.flagBuilder("silent").withAliases("s"))
                 .handler(commandContext -> {
@@ -31,18 +31,6 @@ public class ServerAdminCommand extends AbstractCommand {
                     MultiplePlayerSelector selector = commandContext.get("player");
                     boolean silent = commandContext.flags().hasFlag("silent");
                     var players = selector.values();
-                    if (players.size() == 0) {
-                        if (!silent)
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_PLAYER.build()
-                                            ),
-                                            true
-                                    );
-                        return;
-                    }
                     for (Player player : players) {
                         SparrowBukkitPlugin.getInstance().getBungeeManager().connectServer(player, server);
                     }

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/SmithingTableAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/SmithingTableAdminCommand.java
@@ -22,24 +22,12 @@ public class SmithingTableAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser())
+                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser(false))
                 .flag(manager.flagBuilder("silent").withAliases("s"))
                 .handler(commandContext -> {
                     MultiplePlayerSelector selector = commandContext.get("player");
                     boolean silent = commandContext.flags().hasFlag("silent");
                     var players = selector.values();
-                    if (players.size() == 0) {
-                        if (!silent)
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_PLAYER.build()
-                                            ),
-                                            true
-                                    );
-                        return;
-                    }
                     for (Player player : players) {
                         player.openSmithingTable(null, true);
                     }

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/StoneCutterAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/StoneCutterAdminCommand.java
@@ -22,24 +22,12 @@ public class StoneCutterAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser())
+                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser(false))
                 .flag(manager.flagBuilder("silent").withAliases("s"))
                 .handler(commandContext -> {
                     MultiplePlayerSelector selector = commandContext.get("player");
                     boolean silent = commandContext.flags().hasFlag("silent");
                     var players = selector.values();
-                    if (players.size() == 0) {
-                        if (!silent)
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_PLAYER.build()
-                                            ),
-                                            true
-                                    );
-                        return;
-                    }
                     for (Player player : players) {
                         player.openStonecutter(null, true);
                     }

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/SudoAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/SudoAdminCommand.java
@@ -23,7 +23,7 @@ public class SudoAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser())
+                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser(false))
                 .required("command", StringParser.greedyFlagYieldingStringParser())
                 .flag(manager.flagBuilder("silent").withAliases("s"))
                 .handler(commandContext -> {
@@ -31,18 +31,6 @@ public class SudoAdminCommand extends AbstractCommand {
                     String command = commandContext.get("command");
                     boolean silent = commandContext.flags().hasFlag("silent");
                     var players = selector.values();
-                    if (players.size() == 0) {
-                        if (!silent)
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_PLAYER.build()
-                                            ),
-                                            true
-                                    );
-                        return;
-                    }
                     for (Player player : players) {
                         player.performCommand(command);
                     }

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/TitleAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/TitleAdminCommand.java
@@ -27,7 +27,7 @@ public class TitleAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser())
+                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser(false))
                 .required("fadeIn", IntegerParser.integerParser(0))
                 .required("stay", IntegerParser.integerParser(0))
                 .required("fadeOut", IntegerParser.integerParser(0))
@@ -59,20 +59,8 @@ public class TitleAdminCommand extends AbstractCommand {
                         }
                         return;
                     }
-                    title = split[0].equals("") ? null : split[0];
-                    subTitle = split.length == 2 && !split[1].equals("") ? split[1] : null;
-                    if (players.size() == 0) {
-                        if (!silent)
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_PLAYER.build()
-                                            ),
-                                            true
-                                    );
-                        return;
-                    }
+                    title = split[0].isEmpty() ? null : split[0];
+                    subTitle = split.length == 2 && !split[1].isEmpty() ? split[1] : null;
                     for (Player player : players) {
                         SparrowBukkitPlugin.getInstance().getCoreNMSBridge().getHeart().sendTitle(
                                 player,

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/ToastAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/ToastAdminCommand.java
@@ -28,7 +28,7 @@ public class ToastAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser())
+                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser(false))
                 .required("type", EnumParser.enumParser(AdvancementType.class))
                 .required("item", ItemStackParser.itemStackParser())
                 .required("message", StringParser.greedyFlagYieldingStringParser())
@@ -43,18 +43,6 @@ public class ToastAdminCommand extends AbstractCommand {
                     String message = commandContext.get("message");
                     AdvancementType type = commandContext.get("type");
                     boolean silent = commandContext.flags().hasFlag("silent");
-                    if (players.size() == 0) {
-                        if (!silent)
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_PLAYER.build()
-                                            ),
-                                            true
-                                    );
-                        return;
-                    }
                     for (Player player : players) {
                         SparrowBukkitPlugin.getInstance().getCoreNMSBridge().getHeart().sendToast(
                                 player,

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/TopBlockAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/TopBlockAdminCommand.java
@@ -23,25 +23,12 @@ public class TopBlockAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("entity", MultipleEntitySelectorParser.multipleEntitySelectorParser())
+                .required("entity", MultipleEntitySelectorParser.multipleEntitySelectorParser(false))
                 .flag(manager.flagBuilder("silent").withAliases("s"))
                 .handler(commandContext -> {
                     MultipleEntitySelector selector = commandContext.get("entity");
                     boolean silent = commandContext.flags().hasFlag("silent");
                     var entities = selector.values();
-                    if (entities.size() == 0) {
-                        if (!silent) {
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_ENTITY.build()
-                                            ),
-                                            true
-                                    );
-                        }
-                        return;
-                    }
                     for (Entity entity : entities) {
                         EntityUtils.toTopBlockPosition(entity);
                     }

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/TpOfflineAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/TpOfflineAdminCommand.java
@@ -27,7 +27,7 @@ public class TpOfflineAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("entity", MultipleEntitySelectorParser.multipleEntitySelectorParser())
+                .required("entity", MultipleEntitySelectorParser.multipleEntitySelectorParser(false))
                 .required("player", StringParser.stringParser())
                 .flag(manager.flagBuilder("silent").withAliases("s"))
                 .handler(commandContext -> {
@@ -51,19 +51,6 @@ public class TpOfflineAdminCommand extends AbstractCommand {
 
                     MultipleEntitySelector selector = commandContext.get("entity");
                     var entities = selector.values();
-                    if (entities.size() == 0) {
-                        if (!silent) {
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_ENTITY.build()
-                                            ),
-                                            true
-                                    );
-                        }
-                        return;
-                    }
 
                     for (Entity entity : entities) {
                         entity.teleport(player.getLocation());

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/WalkSpeedAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/WalkSpeedAdminCommand.java
@@ -23,7 +23,7 @@ public class WalkSpeedAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser())
+                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser(false))
                 .required("speed", FloatParser.floatParser(-1, 1))
                 .flag(manager.flagBuilder("silent").withAliases("s"))
                 .handler(commandContext -> {
@@ -31,18 +31,6 @@ public class WalkSpeedAdminCommand extends AbstractCommand {
                     float speed = commandContext.get("speed");
                     boolean silent = commandContext.flags().hasFlag("silent");
                     var players = selector.values();
-                    if (players.size() == 0) {
-                        if (!silent)
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_PLAYER.build()
-                                            ),
-                                            true
-                                    );
-                        return;
-                    }
                     for (Player player : players) {
                         player.setWalkSpeed(speed);
                     }

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/WorkbenchAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/WorkbenchAdminCommand.java
@@ -22,25 +22,13 @@ public class WorkbenchAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser())
+                .required("player", MultiplePlayerSelectorParser.multiplePlayerSelectorParser(false))
                 .flag(manager.flagBuilder("silent").withAliases("s"))
                 .flag(manager.flagBuilder("silent").withAliases("s"))
                 .handler(commandContext -> {
                     MultiplePlayerSelector selector = commandContext.get("player");
                     boolean silent = commandContext.flags().hasFlag("silent");
                     var players = selector.values();
-                    if (players.size() == 0) {
-                        if (!silent)
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_PLAYER.build()
-                                            ),
-                                            true
-                                    );
-                        return;
-                    }
                     for (Player player : players) {
                         player.openWorkbench(null, true);
                     }

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/WorldAdminCommand.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/command/feature/WorldAdminCommand.java
@@ -25,7 +25,7 @@ public class WorldAdminCommand extends AbstractCommand {
     @Override
     public Command.Builder<? extends CommandSender> assembleCommand(BukkitCommandManager<CommandSender> manager, Command.Builder<CommandSender> builder) {
         return builder
-                .required("entity", MultipleEntitySelectorParser.multipleEntitySelectorParser())
+                .required("entity", MultipleEntitySelectorParser.multipleEntitySelectorParser(false))
                 .required("world", WorldParser.worldParser())
                 .flag(manager.flagBuilder("silent").withAliases("s"))
                 .handler(commandContext -> {
@@ -33,19 +33,6 @@ public class WorldAdminCommand extends AbstractCommand {
                     MultipleEntitySelector selector = commandContext.get("entity");
                     boolean silent = commandContext.flags().hasFlag("silent");
                     var entities = selector.values();
-                    if (entities.size() == 0) {
-                        if (!silent) {
-                            SparrowBukkitPlugin.getInstance().getSenderFactory()
-                                    .wrap(commandContext.sender())
-                                    .sendMessage(
-                                            TranslationManager.render(
-                                                    Message.ARGUMENT_ENTITY_NOTFOUND_ENTITY.build()
-                                            ),
-                                            true
-                                    );
-                        }
-                        return;
-                    }
                     for (Entity entity : entities) {
                         EntityUtils.changeWorld(entity, world);
                     }

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/util/EntityUtils.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/util/EntityUtils.java
@@ -7,11 +7,14 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
-public class EntityUtils {
+public final class EntityUtils {
 
     private EntityUtils() {}
 
@@ -34,14 +37,22 @@ public class EntityUtils {
     }
 
     public static void toTopBlockPosition(Entity entity) {
-         var location = entity.getLocation();
-         var block = location.getWorld().getHighestBlockAt(location.getBlockX(), location.getBlockZ());
-         var newLocation = location.clone();
-         newLocation.setY(block.isPassable() ? block.getY() : block.getY() + 1);
-         entity.teleport(newLocation);
+        var location = entity.getLocation();
+        var block = location.getWorld().getHighestBlockAt(location.getBlockX(), location.getBlockZ());
+        var newLocation = location.clone();
+        newLocation.setY(block.isPassable() ? block.getY() : block.getY() + 1);
+        entity.teleport(newLocation);
     }
-
-    public static void changeWorld(@NotNull Entity entity, World to) {
+    
+    /**
+     * Changes the world of the entity. The location of the entity will be adjusted to the new world.
+     *
+     * @param entity the entity to change the world of.
+     * @param to the world to change to.
+     */
+    public static void changeWorld(@NotNull Entity entity, @NotNull World to) {
+        requireNonNull(entity, "entity");
+        requireNonNull(to, "to");
         var fromEnv = entity.getWorld().getEnvironment();
         var toEnv = to.getEnvironment();
         var location = entity.getLocation();
@@ -73,5 +84,14 @@ public class EntityUtils {
             }
         }
         entity.teleport(toLocation.subtract(0,height - 1,0));
+    }
+
+    @Nullable
+    public static Inventory getEntityInventory(@NotNull Entity entity) {
+        requireNonNull(entity, "entity");
+        if (entity instanceof InventoryHolder holder) {
+            return holder.getInventory();
+        }
+        return null;
     }
 }

--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/util/LocationUtils.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/util/LocationUtils.java
@@ -4,7 +4,7 @@ import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 
-public class LocationUtils {
+public final class LocationUtils {
 
     private LocationUtils() {}
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -9,4 +9,6 @@ dependencies {
     compileOnly("org.slf4j:slf4j-api:2.0.13")
     compileOnly("org.apache.logging.log4j:log4j-core:2.23.1")
     compileOnly("com.google.code.gson:gson:2.10.1")
+    compileOnly("org.incendo:cloud-core:2.0.0-beta.5")
+    compileOnly("org.incendo:cloud-minecraft-extras:2.0.0-beta.5")
 }

--- a/common/src/main/java/net/momirealms/sparrow/common/locale/Message.java
+++ b/common/src/main/java/net/momirealms/sparrow/common/locale/Message.java
@@ -54,6 +54,7 @@ public interface Message {
     TranslatableComponent.Builder COMMANDS_PLAYER_SERVER_SUCCESS = Component.translatable().key("commands.player.server.success");
     TranslatableComponent.Builder COMMANDS_ADMIN_SERVER_SUCCESS_SINGLE = Component.translatable().key("commands.admin.server.success.single");
     TranslatableComponent.Builder COMMANDS_ADMIN_SERVER_SUCCESS_MULTIPLE = Component.translatable().key("commands.admin.server.success.multiple");
+    TranslatableComponent.Builder COMMANDS_ADMIN_PATROL_FAILED_TARGET = Component.translatable().key("commands.admin.patrol.failed.target");
     TranslatableComponent.Builder COMMANDS_ADMIN_PATROL_SUCCESS = Component.translatable().key("commands.admin.patrol.success");
     TranslatableComponent.Builder COMMANDS_PLAYER_FEED_SUCCESS = Component.translatable().key("commands.player.feed.success");
     TranslatableComponent.Builder COMMANDS_ADMIN_FEED_SUCCESS_SINGLE = Component.translatable().key("commands.admin.feed.success.single");

--- a/common/src/main/java/net/momirealms/sparrow/common/locale/Message.java
+++ b/common/src/main/java/net/momirealms/sparrow/common/locale/Message.java
@@ -5,8 +5,6 @@ import net.kyori.adventure.text.TranslatableComponent;
 
 public interface Message {
 
-    TranslatableComponent.Builder ARGUMENT_ENTITY_NOTFOUND_ENTITY = Component.translatable().key("argument.entity.notfound.entity");
-    TranslatableComponent.Builder ARGUMENT_ENTITY_NOTFOUND_PLAYER = Component.translatable().key("argument.entity.notfound.player");
     TranslatableComponent.Builder COMMANDS_ADMIN_RELOAD_SUCCESS = Component.translatable().key("commands.admin.reload.success");
     TranslatableComponent.Builder COMMANDS_PLAYER_CARTOGRAPHY_TABLE_SUCCESS = Component.translatable().key("commands.player.cartography_table.success");
     TranslatableComponent.Builder COMMANDS_ADMIN_CARTOGRAPHY_TABLE_SUCCESS_SINGLE = Component.translatable().key("commands.admin.cartography_table.success.single");

--- a/common/src/main/java/net/momirealms/sparrow/common/locale/SparrowCaptionFormatter.java
+++ b/common/src/main/java/net/momirealms/sparrow/common/locale/SparrowCaptionFormatter.java
@@ -1,0 +1,17 @@
+package net.momirealms.sparrow.common.locale;
+
+import net.kyori.adventure.text.Component;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.incendo.cloud.caption.Caption;
+import org.incendo.cloud.caption.CaptionVariable;
+import org.incendo.cloud.minecraft.extras.caption.ComponentCaptionFormatter;
+
+import java.util.List;
+
+public class SparrowCaptionFormatter<C> implements ComponentCaptionFormatter<C> {
+    @Override
+    public @NonNull Component formatCaption(@NonNull Caption captionKey, @NonNull C recipient, @NonNull String caption, @NonNull List<@NonNull CaptionVariable> variables) {
+        Component component = ComponentCaptionFormatter.translatable().formatCaption(captionKey, recipient, caption, variables);
+        return TranslationManager.render(component);
+    }
+}

--- a/common/src/main/java/net/momirealms/sparrow/common/sender/SenderFactory.java
+++ b/common/src/main/java/net/momirealms/sparrow/common/sender/SenderFactory.java
@@ -25,6 +25,7 @@
 
 package net.momirealms.sparrow.common.sender;
 
+import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.momirealms.sparrow.common.plugin.SparrowPlugin;
 import net.momirealms.sparrow.common.util.Tristate;
@@ -52,6 +53,8 @@ public abstract class SenderFactory<P extends SparrowPlugin, T> implements AutoC
     protected abstract UUID getUniqueId(T sender);
 
     protected abstract String getName(T sender);
+
+    protected abstract Audience getAudience(T sender);
 
     protected abstract void sendMessage(T sender, Component message);
 

--- a/common/src/main/resources/translations/en.yml
+++ b/common/src/main/resources/translations/en.yml
@@ -15,6 +15,7 @@ config-version: "1"
 #     - First line
 #     - Second line
 #
+exception.invalid_syntax: "<red>Invalid syntax. Correct syntax: <white><arg:0></white></red>"
 commands.admin.reload.success: "<gray>Reloaded. Took <green><arg:0></green> ms</gray>"
 commands.player.anvil.success: "<gray>You opened the anvil</gray>"
 commands.admin.anvil.success.single: "<gray>Opened anvil for <white><arg:0></white></gray>"

--- a/common/src/main/resources/translations/en.yml
+++ b/common/src/main/resources/translations/en.yml
@@ -15,8 +15,6 @@ config-version: "1"
 #     - First line
 #     - Second line
 #
-argument.entity.notfound.entity: "<red><lang:argument.entity.notfound.entity></red>"
-argument.entity.notfound.player: "<red><lang:argument.entity.notfound.player></red>"
 commands.admin.reload.success: "<gray>Reloaded. Took <green><arg:0></green> ms</gray>"
 commands.player.anvil.success: "<gray>You opened the anvil</gray>"
 commands.admin.anvil.success.single: "<gray>Opened anvil for <white><arg:0></white></gray>"

--- a/common/src/main/resources/translations/en.yml
+++ b/common/src/main/resources/translations/en.yml
@@ -16,6 +16,8 @@ config-version: "1"
 #     - Second line
 #
 exception.invalid_syntax: "<red>Invalid syntax. Correct syntax: <white><arg:0></white></red>"
+exception.invalid_argument: "<red>Invalid argument. Reason: <white><arg:0></white></red>"
+argument.parse.failure.enchantment: "<red>Failed to parse enchantment: <white><arg:0></white></red>"
 commands.admin.reload.success: "<gray>Reloaded. Took <green><arg:0></green> ms</gray>"
 commands.player.anvil.success: "<gray>You opened the anvil</gray>"
 commands.admin.anvil.success.single: "<gray>Opened anvil for <white><arg:0></white></gray>"

--- a/common/src/main/resources/translations/en.yml
+++ b/common/src/main/resources/translations/en.yml
@@ -60,6 +60,7 @@ commands.admin.flyspeed.success.multiple: "<gray>Modified fly speed for <white><
 commands.player.world.success: "<gray>Changed world to <white><arg:0></white></gray>"
 commands.admin.world.success.single: "<gray>Changed world for <white><arg:0></white></gray> to <white><arg:1></white>"
 commands.admin.world.success.multiple: "<gray>Changed world for <white><arg:0></white> entities</gray> to <white><arg:1></white>"
+commands.admin.patrol.failed.target: "<red>No target be selected</red>"
 commands.admin.patrol.success: "<gray>Now patrolling <white><arg:0></white></gray>"
 commands.player.suicide.success: "<gray>You suicided</gray>"
 commands.player.server.success: "<gray>Changed server to <white><arg:0></white></gray>"

--- a/common/src/main/resources/translations/zh_cn.yml
+++ b/common/src/main/resources/translations/zh_cn.yml
@@ -15,8 +15,6 @@ config-version: "1"
 #     - 第一行
 #     - 第二行
 #
-argument.entity.notfound.entity: "<red><lang:argument.entity.notfound.entity></red>"
-argument.entity.notfound.player: "<red><lang:argument.entity.notfound.player></red>"
 commands.admin.reload.success: "<gray>已重新加载配置文件。耗时<green><arg:0></green>毫秒</gray><newline><green><click:open_url:https://github.com/jhqwqmc>译者：jhqwqmc</click></green>"
 commands.player.anvil.success: "<gray>你打开了铁砧</gray>"
 commands.admin.anvil.success.single: "<gray>为<white><arg:0></white>打开了铁砧</gray>"

--- a/common/src/main/resources/translations/zh_cn.yml
+++ b/common/src/main/resources/translations/zh_cn.yml
@@ -60,6 +60,7 @@ commands.admin.flyspeed.success.multiple: "<gray>修改了<white><arg:0></white>
 commands.player.world.success: "<gray>你已传送到<white><arg:0></white>世界</gray>"
 commands.admin.world.success.single: "<gray>已将<white><arg:0></white>传送到<white><arg:1></white>世界</gray>"
 commands.admin.world.success.multiple: "<gray>已将<white><arg:0></white>个实体传送到<white><arg:1></white>世界</gray>"
+commands.admin.patrol.failed.target: "<red>没有目标被选中</red>"
 commands.admin.patrol.success: "<gray>现在正在巡查<white><arg:0></white></gray>"
 commands.player.suicide.success: "<gray>你紫砂了</gray>"
 commands.player.server.success: "<gray>你已传送到<white><arg:0></white>服务器</gray>"

--- a/common/src/main/resources/translations/zh_cn.yml
+++ b/common/src/main/resources/translations/zh_cn.yml
@@ -16,6 +16,8 @@ config-version: "1"
 #     - 第二行
 #
 exception.invalid_syntax: "<red>无效的语法。正确的语法: <white><arg:0></white></red>"
+exception.invalid_argument: "<red>无效的参数。原因: <white><arg:0></white></red>"
+argument.parse.failure.enchantment: "<red>无法解析附魔<white><arg:0></white></red>"
 commands.admin.reload.success: "<gray>已重新加载配置文件。耗时<green><arg:0></green>毫秒</gray><newline><green><click:open_url:https://github.com/jhqwqmc>译者：jhqwqmc</click></green>"
 commands.player.anvil.success: "<gray>你打开了铁砧</gray>"
 commands.admin.anvil.success.single: "<gray>为<white><arg:0></white>打开了铁砧</gray>"

--- a/common/src/main/resources/translations/zh_cn.yml
+++ b/common/src/main/resources/translations/zh_cn.yml
@@ -15,6 +15,7 @@ config-version: "1"
 #     - 第一行
 #     - 第二行
 #
+exception.invalid_syntax: "<red>无效的语法。正确的语法: <white><arg:0></white></red>"
 commands.admin.reload.success: "<gray>已重新加载配置文件。耗时<green><arg:0></green>毫秒</gray><newline><green><click:open_url:https://github.com/jhqwqmc>译者：jhqwqmc</click></green>"
 commands.player.anvil.success: "<gray>你打开了铁砧</gray>"
 commands.admin.anvil.success.single: "<gray>为<white><arg:0></white>打开了铁砧</gray>"


### PR DESCRIPTION
Use `MultipleEntitySelectorParser.multipleEntitySelectorParser(false)` instead of checking by ourselves.
This will prevent users when their type the empty selector in commands.