### PR TITLE
Sparrow-Heart 0.59 & 1.21.8 support

### DIFF
--- a/bukkit/src/main/java/net/momirealms/sparrow/bukkit/feature/item/SparrowBukkitItemFactory.java
+++ b/bukkit/src/main/java/net/momirealms/sparrow/bukkit/feature/item/SparrowBukkitItemFactory.java
@@ -34,7 +34,7 @@ public abstract class SparrowBukkitItemFactory extends ItemFactory<SparrowBukkit
             case "1.21.4" -> {
                 return new ComponentItemFactory1_21_4(plugin);
             }
-            case "1.21.5", "1.21.6", "1.21.7" -> {
+            case "1.21.5", "1.21.6", "1.21.7", "1.21.8" -> {
                 return new ComponentItemFactory1_21_5(plugin);
             }
             default -> throw new IllegalStateException("Unsupported server version: " + plugin.getBootstrap().getServerVersion());

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,7 @@ config_version=2
 project_group=net.momirealms
 
 # Dependency settings
+sparrow_heart_version=0.59
 paper_version=1.20.4
 jetbrains_annotations_version=24.0.0
 slf4j_version=2.0.16
@@ -17,7 +18,6 @@ h2_driver_version=2.3.232
 sqlite_driver_version=3.48.0.0
 adventure_bundle_version=4.23.0
 adventure_platform_version=4.4.0
-sparrow_heart_version=0.58
 cloud_core_version=2.0.0
 cloud_services_version=2.0.0
 cloud_brigadier_version=2.0.0-beta.10


### PR DESCRIPTION
# ⚠️ PLEASE YOU MUST MERGE THIS PR AFTER YOU MERGE https://github.com/Xiao-MoMi/Sparrow-Heart/pull/1 ⚠️
-----
This pull request includes updates to support a new server version, a dependency version bump, and a configuration update. Below are the most important changes:

### Server version support:
* Added support for Minecraft server version `1.21.8` in the `SparrowBukkitItemFactory` by updating the version matching logic to include this version. (`bukkit/src/main/java/net/momirealms/sparrow/bukkit/feature/item/SparrowBukkitItemFactory.java`, [bukkit/src/main/java/net/momirealms/sparrow/bukkit/feature/item/SparrowBukkitItemFactory.javaL37-R37](diffhunk://#diff-fa67fac4e1d16e2b47589fb420bfdc660bc557231e61340409685764922bbb8bL37-R37))

### Dependency updates:
* Updated the `sparrow_heart_version` dependency from `0.58` to `0.59` in `gradle.properties`. (`gradle.properties`, [[1]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19R8) [[2]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L20)